### PR TITLE
Improve Debian 13 (Trixie) compatibility

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -399,7 +399,7 @@ install_bashrc_support() {
             if command -v nala &> /dev/null; then
                 sudo nala install -y bash bash-completion tar bat tree multitail curl wget unzip fontconfig joe git plocate nano fish zoxide trash-cli fzf pwgen powerline neovim ripgrep
             else
-                sudo apt install -y bash bash-completion tar batcat tree multitail curl wget unzip fontconfig joe git plocate nano fish zoxide trash-cli fzf pwgen powerline-go neovim ripgrep
+                sudo apt install -y bash bash-completion tar batcat tree multitail curl wget unzip fontconfig joe git plocate nano fish zoxide trash-cli fzf pwgen powerline neovim ripgrep
             fi
             ;;
         "arch")

--- a/.zshrc
+++ b/.zshrc
@@ -175,9 +175,9 @@ else
     alias grep="/usr/bin/grep --color=auto"
 fi
 
-if [[ "$DISTRIBUTION" == "arch" ]]; then
+if command -v bat &> /dev/null; then
     alias cat='bat'
-else
+elif command -v batcat &> /dev/null; then
     alias cat='batcat'
 fi
 

--- a/check_dependencies.sh
+++ b/check_dependencies.sh
@@ -14,7 +14,7 @@ echo "Checking DXSBash dependencies..."
 echo "================================"
 
 REQUIRED="git curl bash"
-OPTIONAL="zsh fish starship zoxide fzf fastfetch bat ripgrep tree multitail nano nvim docker kubectl xclip xdotool notify-send bc lsof openssl"
+OPTIONAL="zsh fish starship zoxide fzf fastfetch ripgrep tree multitail nano nvim docker kubectl xclip xdotool notify-send bc lsof openssl btop"
 
 echo "Required:"
 for cmd in $REQUIRED; do
@@ -26,3 +26,14 @@ echo "Optional:"
 for cmd in $OPTIONAL; do
     check_command "$cmd"
 done
+
+# bat is packaged as 'batcat' on Debian/Ubuntu
+echo ""
+echo "Checking bat (syntax-highlighted cat):"
+if command -v bat &> /dev/null; then
+    echo "✓ bat"
+elif command -v batcat &> /dev/null; then
+    echo "✓ batcat (Debian/Ubuntu naming)"
+else
+    echo "✗ bat / batcat (missing) — install the 'bat' package"
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -157,12 +157,13 @@ detectDistro() {
   # Detect if we're on Debian or Ubuntu
   if [ -f /etc/debian_version ]; then
     if [ -f /etc/lsb-release ] && grep -q "Ubuntu" /etc/lsb-release; then
-    echo -e "${GREEN}  ✓ Detected ${WHITE}Ubuntu Linux${RC}"
-    IS_DEBIAN_BASED=true
-    elif [ -f /etc/debian_version ]; then
-    echo -e "${GREEN}  ✓ Detected ${WHITE}Debian Linux${RC}"
-    IS_DEBIAN_BASED=true
-fi
+      echo -e "${GREEN}  ✓ Detected ${WHITE}Ubuntu Linux${RC}"
+      IS_DEBIAN_BASED=true
+    else
+      DEBIAN_VERSION=$(cat /etc/debian_version)
+      echo -e "${GREEN}  ✓ Detected ${WHITE}Debian Linux ${CYAN}(${DEBIAN_VERSION})${RC}"
+      IS_DEBIAN_BASED=true
+    fi
   else
     echo -e "${RED}  ⚠ Warning: DXSBash is designed specifically for Debian and Ubuntu.${RC}"
     echo -e "${YELLOW}  Your system appears to be running a different distribution.${RC}"
@@ -187,7 +188,7 @@ installDepend() {
   COMMON_DEPENDENCIES='bash tar bat tree multitail curl wget unzip fontconfig joe git nano zoxide fzf pwgen ripgrep fastfetch'
 
   # Shell-specific dependencies
-  BASH_DEPENDENCIES="bash bash-completion bashacks bashacks-doc bashtop"
+  BASH_DEPENDENCIES="bash bash-completion btop"
   ZSH_DEPENDENCIES="zsh zsh-autosuggestions zsh-syntax-highlighting"
   FISH_DEPENDENCIES="fish"
 
@@ -195,7 +196,9 @@ installDepend() {
   DEPENDENCIES="$COMMON_DEPENDENCIES nala plocate trash-cli powerline"
 
   # Add shell-specific dependencies
-  if [ "$SELECTED_SHELL" = "zsh" ]; then
+  if [ "$SELECTED_SHELL" = "bash" ]; then
+    DEPENDENCIES="$DEPENDENCIES $BASH_DEPENDENCIES"
+  elif [ "$SELECTED_SHELL" = "zsh" ]; then
     DEPENDENCIES="$DEPENDENCIES $ZSH_DEPENDENCIES"
   elif [ "$SELECTED_SHELL" = "fish" ]; then
     DEPENDENCIES="$DEPENDENCIES $FISH_DEPENDENCIES"

--- a/test_compatibility.sh
+++ b/test_compatibility.sh
@@ -4,37 +4,96 @@ set -euo pipefail
 echo "Testing Debian 13 Trixie Compatibility..."
 
 # Check Debian version
-if ! grep -q "13\|trixie" /etc/debian_version; then
-    echo "Warning: Not running on Debian 13 Trixie"
+if [ -f /etc/debian_version ]; then
+    DEBIAN_VER=$(cat /etc/debian_version)
+    if echo "$DEBIAN_VER" | grep -qE "^13\.|trixie"; then
+        echo "✓ Running on Debian 13 Trixie (${DEBIAN_VER})"
+    else
+        echo "⚠ Warning: Not running on Debian 13 Trixie (detected: ${DEBIAN_VER})"
+    fi
+else
+    echo "⚠ Warning: /etc/debian_version not found — not a Debian system"
 fi
 
-# Test critical commands
-COMMANDS=(
-    "bash:5.2"
-    "python3:3.12"
-    "git:2.45"
-    "systemctl:256"
-)
+# Compare semantic versions: returns 0 if $1 >= $2
+version_ge() {
+    [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]
+}
 
-for cmd_ver in "${COMMANDS[@]}"; do
-    IFS=':' read -r cmd min_ver <<< "$cmd_ver"
-    if command -v "$cmd" &>/dev/null; then
-        echo "✓ $cmd found"
-    else
-        echo "✗ $cmd missing"
+# Test critical commands and their minimum versions
+echo ""
+echo "Checking required commands and versions:"
+
+check_version() {
+    local cmd="$1"
+    local min_ver="$2"
+    local ver_flag="${3:---version}"
+
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "✗ $cmd — not found"
+        return 1
     fi
-done
+
+    local actual_ver
+    actual_ver=$("$cmd" $ver_flag 2>&1 | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1 || true)
+
+    if [ -z "$actual_ver" ]; then
+        echo "? $cmd — found but could not determine version"
+        return 0
+    fi
+
+    if version_ge "$actual_ver" "$min_ver"; then
+        echo "✓ $cmd ${actual_ver} (>= ${min_ver} required)"
+    else
+        echo "✗ $cmd ${actual_ver} is below minimum required ${min_ver}"
+        return 1
+    fi
+}
+
+check_version bash  5.2
+check_version python3 3.12
+check_version git   2.45
+# systemd version is reported differently
+if command -v systemctl &>/dev/null; then
+    SYSTEMD_VER=$(systemctl --version 2>&1 | grep -oE '^systemd [0-9]+' | grep -oE '[0-9]+' || true)
+    if [ -n "$SYSTEMD_VER" ] && [ "$SYSTEMD_VER" -ge 256 ] 2>/dev/null; then
+        echo "✓ systemd ${SYSTEMD_VER} (>= 256 required)"
+    elif [ -n "$SYSTEMD_VER" ]; then
+        echo "✗ systemd ${SYSTEMD_VER} is below minimum required 256"
+    else
+        echo "? systemctl — found but could not determine version"
+    fi
+else
+    echo "✗ systemctl — not found"
+fi
 
 # Check for deprecated packages
+echo ""
+echo "Checking for deprecated packages:"
 DEPRECATED=(
     "python3-distutils"
     "nodejs-legacy"
+    "bashtop"
 )
 
 for pkg in "${DEPRECATED[@]}"; do
     if dpkg -l "$pkg" &>/dev/null 2>&1; then
-        echo "⚠ Deprecated package found: $pkg"
+        echo "⚠ Deprecated package installed: $pkg"
+    else
+        echo "✓ $pkg not installed"
     fi
 done
 
+# Check bat binary naming (Debian uses 'batcat' instead of 'bat')
+echo ""
+echo "Checking bat binary naming:"
+if command -v batcat &>/dev/null; then
+    echo "✓ batcat found (Debian naming convention)"
+elif command -v bat &>/dev/null; then
+    echo "✓ bat found"
+else
+    echo "✗ Neither bat nor batcat found — install the 'bat' package"
+fi
+
+echo ""
 echo "Compatibility check complete"


### PR DESCRIPTION
- setup.sh: remove unavailable packages (bashacks, bashacks-doc, bashtop)
  from BASH_DEPENDENCIES; replace bashtop with btop; wire BASH_DEPENDENCIES
  into install for bash shell selection; fix redundant detectDistro elif and
  display detected Debian version number
- .bashrc: fix powerline-go → powerline in apt (non-nala) install path;
  powerline-go is not in Debian 13 official repos
- .zshrc: replace hardcoded `alias cat='batcat'` with bat/batcat command
  check, matching the safer logic already used in .bashrc
- test_compatibility.sh: rewrite version checks to actually compare semver
  values, add batcat binary naming check, improve deprecated package list
- check_dependencies.sh: handle bat/batcat naming difference on Debian;
  add btop to optional tools list