### PR TITLE
Add Starship theme selector to dxsbash-config

### DIFF
--- a/dxsbash-config.sh
+++ b/dxsbash-config.sh
@@ -22,12 +22,31 @@ DIM='\033[2m'
 CONF_DIR="$HOME/.dxsbash"
 CONF_FILE="$CONF_DIR/user.conf"
 
+# DXSBash repository location (matches setup.sh's install path). Used
+# to resolve Starship theme preset files.
+DXSBASH_DIR="${DXSBASH_DIR:-$HOME/linuxtoolbox/dxsbash}"
+STARSHIP_CONFIG="$HOME/.config/starship.toml"
+STARSHIP_THEMES_DIR="$DXSBASH_DIR/starship-themes"
+
+# ── Starship theme registry ───────────────────────────────────────
+# Display name | filename in starship-themes/
+STARSHIP_THEMES=(
+    "DXS Starship|dxs-starship.toml"
+    "Nerd Font Symbols|nerd-font-symbols.toml"
+    "Bracketed Segments|bracketed-segments.toml"
+    "Pastel Powerline|pastel-powerline.toml"
+    "Tokyo Night|tokyo-night.toml"
+    "Gruvbox Rainbow|gruvbox-rainbow.toml"
+    "Catppuccin Powerline|catppuccin-powerline.toml"
+)
+
 # ── Defaults ──────────────────────────────────────────────────────
 DEF_EDITOR="nano"
 DEF_HISTSIZE=500
 DEF_HISTFILESIZE=10000
 DEF_FASTFETCH="true"
 DEF_PROMPT_STYLE="starship"
+DEF_STARSHIP_THEME="dxs-starship.toml"
 
 # ── Current (working) values ──────────────────────────────────────
 CUR_EDITOR=""
@@ -35,6 +54,7 @@ CUR_HISTSIZE=""
 CUR_HISTFILESIZE=""
 CUR_FASTFETCH=""
 CUR_PROMPT_STYLE=""
+CUR_STARSHIP_THEME=""
 
 #=================================================================
 # Banner
@@ -69,11 +89,31 @@ _read_conf() {
 # Load config into CUR_* variables
 #=================================================================
 load_config() {
-    CUR_EDITOR=$(       _read_conf "EDITOR"               "$DEF_EDITOR")
-    CUR_HISTSIZE=$(     _read_conf "HISTSIZE"             "$DEF_HISTSIZE")
-    CUR_HISTFILESIZE=$( _read_conf "HISTFILESIZE"         "$DEF_HISTFILESIZE")
-    CUR_FASTFETCH=$(    _read_conf "DXSBASH_FASTFETCH"    "$DEF_FASTFETCH")
-    CUR_PROMPT_STYLE=$( _read_conf "DXSBASH_PROMPT_STYLE" "$DEF_PROMPT_STYLE")
+    CUR_EDITOR=$(         _read_conf "EDITOR"                 "$DEF_EDITOR")
+    CUR_HISTSIZE=$(       _read_conf "HISTSIZE"               "$DEF_HISTSIZE")
+    CUR_HISTFILESIZE=$(   _read_conf "HISTFILESIZE"           "$DEF_HISTFILESIZE")
+    CUR_FASTFETCH=$(      _read_conf "DXSBASH_FASTFETCH"      "$DEF_FASTFETCH")
+    CUR_PROMPT_STYLE=$(   _read_conf "DXSBASH_PROMPT_STYLE"   "$DEF_PROMPT_STYLE")
+    CUR_STARSHIP_THEME=$( _read_conf "DXSBASH_STARSHIP_THEME" "$DEF_STARSHIP_THEME")
+
+    # If the starship symlink points at a known preset, trust the
+    # filesystem over the conf file — users may have run setup.sh or
+    # hand-edited the symlink since the conf was written.
+    if [ -L "$STARSHIP_CONFIG" ]; then
+        local target
+        target="$(readlink "$STARSHIP_CONFIG")"
+        local fname="${target##*/}"
+        case "$fname" in
+            starship.toml|dxs-starship.toml)
+                CUR_STARSHIP_THEME="dxs-starship.toml"
+                ;;
+            nerd-font-symbols.toml|bracketed-segments.toml|\
+            pastel-powerline.toml|tokyo-night.toml|\
+            gruvbox-rainbow.toml|catppuccin-powerline.toml)
+                CUR_STARSHIP_THEME="$fname"
+                ;;
+        esac
+    fi
 }
 
 #=================================================================
@@ -93,6 +133,7 @@ export HISTSIZE=${CUR_HISTSIZE}
 export HISTFILESIZE=${CUR_HISTFILESIZE}
 export DXSBASH_FASTFETCH="${CUR_FASTFETCH}"
 export DXSBASH_PROMPT_STYLE="${CUR_PROMPT_STYLE}"
+export DXSBASH_STARSHIP_THEME="${CUR_STARSHIP_THEME}"
 EOF
     echo ""
     echo -e "${GREEN}  ✓ Saved to ${WHITE}$CONF_FILE${RC}"
@@ -128,16 +169,61 @@ show_current_settings() {
         prompt_label="${CYAN}Starship${RC}${DIM} (falls back to custom if not installed)${RC}"
     fi
 
+    local theme_label
+    theme_label="${CYAN}$(starship_theme_display_name "$CUR_STARSHIP_THEME")${RC}"
+
     echo -e "${BLUE}┌─────────────────────────────────────────────────────────┐${RC}"
     echo -e "${BLUE}│  Current Configuration                                  │${RC}"
     echo -e "${BLUE}├──────────────────────┬──────────────────────────────────┤${RC}"
-    printf "${BLUE}│${RC}  %-20s${BLUE}│${RC}  %-32b${BLUE}│${RC}\n" "Editor"        "${WHITE}$CUR_EDITOR${RC}"
+    printf "${BLUE}│${RC}  %-20s${BLUE}│${RC}  %-32b${BLUE}│${RC}\n" "Editor"         "${WHITE}$CUR_EDITOR${RC}"
     printf "${BLUE}│${RC}  %-20s${BLUE}│${RC}  %-32s${BLUE}│${RC}\n" "History size"   "$CUR_HISTSIZE entries"
     printf "${BLUE}│${RC}  %-20s${BLUE}│${RC}  %-32s${BLUE}│${RC}\n" "History file"   "$CUR_HISTFILESIZE entries"
     printf "${BLUE}│${RC}  %-20s${BLUE}│${RC}  %-32b${BLUE}│${RC}\n" "Fastfetch"      "$fastfetch_label"
     printf "${BLUE}│${RC}  %-20s${BLUE}│${RC}  %-32b${BLUE}│${RC}\n" "Prompt style"   "$prompt_label"
+    printf "${BLUE}│${RC}  %-20s${BLUE}│${RC}  %-32b${BLUE}│${RC}\n" "Starship theme" "$theme_label"
     echo -e "${BLUE}└──────────────────────┴──────────────────────────────────┘${RC}"
     echo ""
+}
+
+#=================================================================
+# Starship theme helpers
+#=================================================================
+# Given a filename (e.g. dxs-starship.toml), return the display name.
+starship_theme_display_name() {
+    local file="$1"
+    local entry name fname
+    for entry in "${STARSHIP_THEMES[@]}"; do
+        name="${entry%%|*}"
+        fname="${entry##*|}"
+        if [ "$fname" = "$file" ]; then
+            echo "$name"
+            return
+        fi
+    done
+    echo "unknown ($file)"
+}
+
+# Switch ~/.config/starship.toml to point at the selected preset.
+# The file under $STARSHIP_THEMES_DIR must exist; the caller is
+# responsible for validating that.
+apply_starship_theme() {
+    local fname="$1"
+    local src="$STARSHIP_THEMES_DIR/$fname"
+
+    if [ ! -e "$src" ]; then
+        echo -e "${RED}  ✗ Theme file not found: $src${RC}"
+        return 1
+    fi
+
+    mkdir -p "$(dirname "$STARSHIP_CONFIG")"
+
+    # Replace any existing file/symlink and re-point at the preset.
+    if [ -L "$STARSHIP_CONFIG" ] || [ -e "$STARSHIP_CONFIG" ]; then
+        rm -f "$STARSHIP_CONFIG"
+    fi
+    ln -s "$src" "$STARSHIP_CONFIG"
+    echo -e "${GREEN}  ✓ Linked $STARSHIP_CONFIG → $src${RC}"
+    return 0
 }
 
 #=================================================================
@@ -280,6 +366,80 @@ configure_prompt() {
 }
 
 #=================================================================
+# Submenu — Starship theme
+#=================================================================
+configure_starship_theme() {
+    display_banner
+    echo -e "${CYAN}▶ Starship Theme${RC}"
+    echo ""
+
+    if [ ! -d "$STARSHIP_THEMES_DIR" ]; then
+        echo -e "${RED}  Themes directory not found: $STARSHIP_THEMES_DIR${RC}"
+        echo -e "${YELLOW}  Run dxsbash-repair or re-install DXSBash.${RC}"
+        echo ""
+        read -rp "  Press Enter to return..."
+        return
+    fi
+
+    local starship_status
+    if command -v starship &>/dev/null; then
+        starship_status="${GREEN}installed${RC}"
+    else
+        starship_status="${RED}not installed${RC}${DIM} (themes will apply once starship is installed)${RC}"
+    fi
+    echo -e "  Starship: $starship_status"
+    echo -e "  Current:  ${WHITE}$(starship_theme_display_name "$CUR_STARSHIP_THEME")${RC}"
+    echo ""
+    echo -e "  Pick a preset:"
+    echo ""
+
+    local i=1
+    local entry name fname marker
+    for entry in "${STARSHIP_THEMES[@]}"; do
+        name="${entry%%|*}"
+        fname="${entry##*|}"
+        marker=""
+        [ "$fname" = "$CUR_STARSHIP_THEME" ] && marker=" ${GREEN}← current${RC}"
+        printf "  ${WHITE}%d)${RC} %s%b\n" "$i" "$name" "$marker"
+        (( i++ ))
+    done
+    echo ""
+    echo -e "  ${WHITE}0)${RC} Back"
+    echo ""
+
+    read -rp "  Choice: " choice
+    if [ "$choice" = "0" ] || [ -z "$choice" ]; then
+        return
+    fi
+    if ! [[ "$choice" =~ ^[0-9]+$ ]] || \
+       [ "$choice" -lt 1 ] || [ "$choice" -gt "${#STARSHIP_THEMES[@]}" ]; then
+        echo -e "${RED}  Invalid choice.${RC}"
+        sleep 1
+        return
+    fi
+
+    entry="${STARSHIP_THEMES[$((choice-1))]}"
+    name="${entry%%|*}"
+    fname="${entry##*|}"
+
+    echo ""
+    if apply_starship_theme "$fname"; then
+        CUR_STARSHIP_THEME="$fname"
+        # Switching to a Starship preset implies the user wants the
+        # Starship prompt active, not the built-in one.
+        if [ "$CUR_PROMPT_STYLE" != "starship" ]; then
+            CUR_PROMPT_STYLE="starship"
+            echo -e "${YELLOW}  Prompt style switched to 'starship'.${RC}"
+        fi
+        save_config
+        echo -e "${GREEN}  Theme set to: ${WHITE}$name${RC}"
+        sleep 1
+    else
+        sleep 2
+    fi
+}
+
+#=================================================================
 # Submenu — Startup display (fastfetch)
 #=================================================================
 configure_fastfetch() {
@@ -323,11 +483,12 @@ reset_to_defaults() {
     display_banner
     echo -e "${YELLOW}  This will reset all DXSBash settings to their defaults:${RC}"
     echo ""
-    echo -e "    Editor       → ${WHITE}$DEF_EDITOR${RC}"
-    echo -e "    HISTSIZE     → ${WHITE}$DEF_HISTSIZE${RC}"
-    echo -e "    HISTFILESIZE → ${WHITE}$DEF_HISTFILESIZE${RC}"
-    echo -e "    Fastfetch    → ${WHITE}$DEF_FASTFETCH${RC}"
-    echo -e "    Prompt style → ${WHITE}$DEF_PROMPT_STYLE${RC}"
+    echo -e "    Editor         → ${WHITE}$DEF_EDITOR${RC}"
+    echo -e "    HISTSIZE       → ${WHITE}$DEF_HISTSIZE${RC}"
+    echo -e "    HISTFILESIZE   → ${WHITE}$DEF_HISTFILESIZE${RC}"
+    echo -e "    Fastfetch      → ${WHITE}$DEF_FASTFETCH${RC}"
+    echo -e "    Prompt style   → ${WHITE}$DEF_PROMPT_STYLE${RC}"
+    echo -e "    Starship theme → ${WHITE}$(starship_theme_display_name "$DEF_STARSHIP_THEME")${RC}"
     echo ""
     read -rp "  Continue? (y/N): " confirm
     if [[ "$confirm" =~ ^[Yy]$ ]]; then
@@ -336,6 +497,8 @@ reset_to_defaults() {
         CUR_HISTFILESIZE="$DEF_HISTFILESIZE"
         CUR_FASTFETCH="$DEF_FASTFETCH"
         CUR_PROMPT_STYLE="$DEF_PROMPT_STYLE"
+        CUR_STARSHIP_THEME="$DEF_STARSHIP_THEME"
+        apply_starship_theme "$DEF_STARSHIP_THEME" >/dev/null 2>&1 || true
         save_config
     else
         echo -e "${YELLOW}  Reset cancelled.${RC}"
@@ -355,8 +518,9 @@ main_menu() {
         echo -e "  ${WHITE}1)${RC} Editor preference       ${DIM}(${CUR_EDITOR})${RC}"
         echo -e "  ${WHITE}2)${RC} Shell history           ${DIM}(HISTSIZE=${CUR_HISTSIZE})${RC}"
         echo -e "  ${WHITE}3)${RC} Prompt style            ${DIM}(${CUR_PROMPT_STYLE})${RC}"
-        echo -e "  ${WHITE}4)${RC} Startup display         ${DIM}(fastfetch=${CUR_FASTFETCH})${RC}"
-        echo -e "  ${WHITE}5)${RC} Reset to defaults"
+        echo -e "  ${WHITE}4)${RC} Starship theme          ${DIM}($(starship_theme_display_name "$CUR_STARSHIP_THEME"))${RC}"
+        echo -e "  ${WHITE}5)${RC} Startup display         ${DIM}(fastfetch=${CUR_FASTFETCH})${RC}"
+        echo -e "  ${WHITE}6)${RC} Reset to defaults"
         echo -e "  ${WHITE}0)${RC} Exit"
         echo ""
 
@@ -365,8 +529,9 @@ main_menu() {
             1) configure_editor ;;
             2) configure_history ;;
             3) configure_prompt ;;
-            4) configure_fastfetch ;;
-            5) reset_to_defaults ;;
+            4) configure_starship_theme ;;
+            5) configure_fastfetch ;;
+            6) reset_to_defaults ;;
             0|"q"|"Q"|"exit") break ;;
             *) echo -e "${RED}  Invalid choice.${RC}"; sleep 1 ;;
         esac

--- a/starship-themes/bracketed-segments.toml
+++ b/starship-themes/bracketed-segments.toml
@@ -1,0 +1,283 @@
+"$schema" = 'https://starship.rs/config-schema.json'
+
+[aws]
+format = '\[[$symbol($profile)(\($region\))(\[$duration\])]($style)\]'
+
+[azure]
+format = '\[[$symbol($subscription)]($style)\]'
+
+[battery]
+format = '\[[$symbol$percentage]($style)\]'
+
+[buf]
+format = '\[[$symbol($version)]($style)\]'
+
+[bun]
+format = '\[[$symbol($version)]($style)\]'
+
+[c]
+format = '\[[$symbol($version(-$name))]($style)\]'
+
+[cmake]
+format = '\[[$symbol($version)]($style)\]'
+
+[cmd_duration]
+format = '\[[⏱ $duration]($style)\]'
+
+[cobol]
+format = '\[[$symbol($version)]($style)\]'
+
+[conda]
+format = '\[[$symbol$environment]($style)\]'
+
+[container]
+format = '\[[$symbol \[$name\]]($style)\]'
+
+[cpp]
+format = '\[[$symbol($version(-$name))]($style)\]'
+
+[crystal]
+format = '\[[$symbol($version)]($style)\]'
+
+[daml]
+format = '\[[$symbol($version)]($style)\]'
+
+[dart]
+format = '\[[$symbol($version)]($style)\]'
+
+[deno]
+format = '\[[$symbol($version)]($style)\]'
+
+[direnv]
+format = '\[[$symbol$loaded/$allowed]($style)\]'
+
+[docker_context]
+format = '\[[$symbol$context]($style)\]'
+
+[dotnet]
+format = '\[[$symbol($version)(🎯 $tfm)]($style)\]'
+
+[elixir]
+format = '\[[$symbol($version \(OTP $otp_version\))]($style)\]'
+
+[elm]
+format = '\[[$symbol($version)]($style)\]'
+
+[erlang]
+format = '\[[$symbol($version)]($style)\]'
+
+[fennel]
+format = '\[[$symbol($version)]($style)\]'
+
+[fortran]
+format = '\[[$symbol($version)]($style)\]'
+
+[fossil_branch]
+format = '\[[$symbol$branch]($style)\]'
+
+[fossil_metrics]
+format = '\[[+$added]($added_style)\]\[[-$deleted]($deleted_style)\]'
+
+[gcloud]
+format = '\[[$symbol$account(@$domain)(\($region\))]($style)\]'
+
+[git_branch]
+format = '\[[$symbol$branch]($style)\]'
+
+[git_commit]
+format = '\[[\($hash$tag\)]($style)\]'
+
+[git_metrics]
+format = '\[[+$added]($added_style)\]\[[-$deleted]($deleted_style)\]'
+
+[git_state]
+format = '\[[$state ($progress_current/$progress_total)]($style)\]'
+
+[git_status]
+format = '([\[$all_status$ahead_behind\]]($style))'
+
+[gleam]
+format = '\[[$symbol($version)]($style)\]'
+
+[golang]
+format = '\[[$symbol($version)]($style)\]'
+
+[gradle]
+format = '\[[$symbol($version)]($style)\]'
+
+[guix_shell]
+format = '\[[$symbol]($style)\]'
+
+[haskell]
+format = '\[[$symbol($version)]($style)\]'
+
+[haxe]
+format = '\[[$symbol($version)]($style)\]'
+
+[helm]
+format = '\[[$symbol($version)]($style)\]'
+
+[hg_branch]
+format = '\[[$symbol$branch]($style)\]'
+
+[hostname]
+format = '\[[$ssh_symbol($hostname)]($style)\] '
+
+[java]
+format = '\[[$symbol($version)]($style)\]'
+
+[jobs]
+format = '\[[$symbol$number]($style)\]'
+
+[julia]
+format = '\[[$symbol($version)]($style)\]'
+
+[kotlin]
+format = '\[[$symbol($version)]($style)\]'
+
+[kubernetes]
+format = '\[[$symbol$context( \($namespace\))]($style)\]'
+
+[localip]
+format = '\[[$localipv4]($style)\]'
+
+[lua]
+format = '\[[$symbol($version)]($style)\]'
+
+[maven]
+format = '\[[$symbol($version)]($style)\]'
+
+[memory_usage]
+format = '\[$symbol[$ram( | $swap)]($style)\]'
+
+[meson]
+format = '\[[$symbol$project]($style)\]'
+
+[mise]
+format = '\[[$symbol$health]($style)\]'
+
+[mojo]
+format = '\[[$symbol($version)]($style)\]'
+
+[nats]
+format = '\[[$symbol$name]($style)\]'
+
+[netns]
+format = '\[[$symbol \[$name\]]($style)\]'
+
+[nim]
+format = '\[[$symbol($version)]($style)\]'
+
+[nix_shell]
+format = '\[[$symbol$state( \($name\))]($style)\]'
+
+[nodejs]
+format = '\[[$symbol($version)]($style)\]'
+
+[ocaml]
+format = '\[[$symbol($version)(\($switch_indicator$switch_name\))]($style)\]'
+
+[odin]
+format = '\[[$symbol($version )]($style)\]'
+
+[opa]
+format = '\[[$symbol($version)]($style)\]'
+
+[openstack]
+format = '\[[$symbol$cloud(\($project\))]($style)\]'
+
+[os]
+format = '\[[$symbol]($style)\]'
+
+[package]
+format = '\[[$symbol$version]($style)\]'
+
+[perl]
+format = '\[[$symbol($version)]($style)\]'
+
+[php]
+format = '\[[$symbol($version)]($style)\]'
+
+[pijul_channel]
+format = '\[[$symbol$channel]($style)\]'
+
+[pixi]
+format = '\[[$symbol$version( $environment)]($style)\]'
+
+[pulumi]
+format = '\[[$symbol$stack]($style)\]'
+
+[purescript]
+format = '\[[$symbol($version)]($style)\]'
+
+[python]
+format = '\[[${symbol}${pyenv_prefix}(${version})(\($virtualenv\))]($style)\]'
+
+[quarto]
+format = '\[[$symbol($version)]($style)\]'
+
+[raku]
+format = '\[[$symbol($version-$vm_version)]($style)\]'
+
+[red]
+format = '\[[$symbol($version)]($style)\]'
+
+[rlang]
+format = '\[[$symbol($version)]($style)\]'
+
+[ruby]
+format = '\[[$symbol($version)]($style)\]'
+
+[rust]
+format = '\[[$symbol($version)]($style)\]'
+
+[scala]
+format = '\[[$symbol($version)]($style)\]'
+
+[shell]
+format = '\[[$indicator]($style)\]'
+
+[singularity]
+format = '\[[$symbol\[$env\]]($style)\]'
+
+[solidity]
+format = '\[[$symbol($version)]($style)\]'
+
+[spack]
+format = '\[[$symbol$environment]($style)\]'
+
+[status]
+format = '\[[$symbol$status]($style)\]'
+
+[sudo]
+format = '\[[as $symbol]($style)\]'
+
+[swift]
+format = '\[[$symbol($version)]($style)\]'
+
+[terraform]
+format = '\[[$symbol$workspace]($style)\]'
+
+[time]
+format = '\[[$time]($style)\]'
+
+[typst]
+format = '\[[$symbol($version)]($style)\]'
+
+[username]
+format = '\[[$user]($style)\]'
+
+[vagrant]
+format = '\[[$symbol($version)]($style)\]'
+
+[vcsh]
+format = '\[vcsh [$symbol$repo]($style)\]'
+
+[vlang]
+format = '\[[$symbol($version)]($style)\]'
+
+[xmake]
+format = '\[[$symbol($version)]($style)\]'
+
+[zig]
+format = '\[[$symbol($version)]($style)\]'

--- a/starship-themes/catppuccin-powerline.toml
+++ b/starship-themes/catppuccin-powerline.toml
@@ -1,0 +1,279 @@
+"$schema" = 'https://starship.rs/config-schema.json'
+
+format = """
+[](red)\
+$os\
+$username\
+[](bg:peach fg:red)\
+$directory\
+[](bg:yellow fg:peach)\
+$git_branch\
+$git_status\
+[](fg:yellow bg:green)\
+$c\
+$rust\
+$golang\
+$nodejs\
+$php\
+$java\
+$kotlin\
+$haskell\
+$python\
+[](fg:green bg:sapphire)\
+$conda\
+[](fg:sapphire bg:lavender)\
+$time\
+[ ](fg:lavender)\
+$cmd_duration\
+$line_break\
+$character"""
+
+palette = 'catppuccin_mocha'
+
+[os]
+disabled = false
+style = "bg:red fg:crust"
+
+[os.symbols]
+Windows = ""
+Ubuntu = "󰕈"
+SUSE = ""
+Raspbian = "󰐿"
+Mint = "󰣭"
+Macos = "󰀵"
+Manjaro = ""
+Linux = "󰌽"
+Gentoo = "󰣨"
+Fedora = "󰣛"
+Alpine = ""
+Amazon = ""
+Android = ""
+AOSC = ""
+Arch = "󰣇"
+Artix = "󰣇"
+CentOS = ""
+Debian = "󰣚"
+Redhat = "󱄛"
+RedHatEnterprise = "󱄛"
+
+[username]
+show_always = true
+style_user = "bg:red fg:crust"
+style_root = "bg:red fg:crust"
+format = '[ $user]($style)'
+
+[directory]
+style = "bg:peach fg:crust"
+format = "[ $path ]($style)"
+truncation_length = 3
+truncation_symbol = "…/"
+
+[directory.substitutions]
+"Documents" = "󰈙 "
+"Downloads" = " "
+"Music" = "󰝚 "
+"Pictures" = " "
+"Developer" = "󰲋 "
+
+[git_branch]
+symbol = ""
+style = "bg:yellow"
+format = '[[ $symbol $branch ](fg:crust bg:yellow)]($style)'
+
+[git_status]
+style = "bg:yellow"
+format = '[[($all_status$ahead_behind )](fg:crust bg:yellow)]($style)'
+
+[nodejs]
+symbol = ""
+style = "bg:green"
+format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+
+[c]
+symbol = " "
+style = "bg:green"
+format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+
+[rust]
+symbol = ""
+style = "bg:green"
+format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+
+[golang]
+symbol = ""
+style = "bg:green"
+format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+
+[php]
+symbol = ""
+style = "bg:green"
+format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+
+[java]
+symbol = " "
+style = "bg:green"
+format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+
+[kotlin]
+symbol = ""
+style = "bg:green"
+format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+
+[haskell]
+symbol = ""
+style = "bg:green"
+format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+
+[python]
+symbol = ""
+style = "bg:green"
+format = '[[ $symbol( $version)(\(#$virtualenv\)) ](fg:crust bg:green)]($style)'
+
+[docker_context]
+symbol = ""
+style = "bg:sapphire"
+format = '[[ $symbol( $context) ](fg:crust bg:sapphire)]($style)'
+
+[conda]
+symbol = "  "
+style = "fg:crust bg:sapphire"
+format = '[$symbol$environment ]($style)'
+ignore_base = false
+
+[time]
+disabled = false
+time_format = "%R"
+style = "bg:lavender"
+format = '[[  $time ](fg:crust bg:lavender)]($style)'
+
+[line_break]
+disabled = true
+
+[character]
+disabled = false
+success_symbol = '[❯](bold fg:green)'
+error_symbol = '[❯](bold fg:red)'
+vimcmd_symbol = '[❮](bold fg:green)'
+vimcmd_replace_one_symbol = '[❮](bold fg:lavender)'
+vimcmd_replace_symbol = '[❮](bold fg:lavender)'
+vimcmd_visual_symbol = '[❮](bold fg:yellow)'
+
+[cmd_duration]
+show_milliseconds = true
+format = " in $duration "
+style = "bg:lavender"
+disabled = false
+show_notifications = true
+min_time_to_notify = 45000
+
+[palettes.catppuccin_mocha]
+rosewater = "#f5e0dc"
+flamingo = "#f2cdcd"
+pink = "#f5c2e7"
+mauve = "#cba6f7"
+red = "#f38ba8"
+maroon = "#eba0ac"
+peach = "#fab387"
+yellow = "#f9e2af"
+green = "#a6e3a1"
+teal = "#94e2d5"
+sky = "#89dceb"
+sapphire = "#74c7ec"
+blue = "#89b4fa"
+lavender = "#b4befe"
+text = "#cdd6f4"
+subtext1 = "#bac2de"
+subtext0 = "#a6adc8"
+overlay2 = "#9399b2"
+overlay1 = "#7f849c"
+overlay0 = "#6c7086"
+surface2 = "#585b70"
+surface1 = "#45475a"
+surface0 = "#313244"
+base = "#1e1e2e"
+mantle = "#181825"
+crust = "#11111b"
+
+[palettes.catppuccin_frappe]
+rosewater = "#f2d5cf"
+flamingo = "#eebebe"
+pink = "#f4b8e4"
+mauve = "#ca9ee6"
+red = "#e78284"
+maroon = "#ea999c"
+peach = "#ef9f76"
+yellow = "#e5c890"
+green = "#a6d189"
+teal = "#81c8be"
+sky = "#99d1db"
+sapphire = "#85c1dc"
+blue = "#8caaee"
+lavender = "#babbf1"
+text = "#c6d0f5"
+subtext1 = "#b5bfe2"
+subtext0 = "#a5adce"
+overlay2 = "#949cbb"
+overlay1 = "#838ba7"
+overlay0 = "#737994"
+surface2 = "#626880"
+surface1 = "#51576d"
+surface0 = "#414559"
+base = "#303446"
+mantle = "#292c3c"
+crust = "#232634"
+
+[palettes.catppuccin_latte]
+rosewater = "#dc8a78"
+flamingo = "#dd7878"
+pink = "#ea76cb"
+mauve = "#8839ef"
+red = "#d20f39"
+maroon = "#e64553"
+peach = "#fe640b"
+yellow = "#df8e1d"
+green = "#40a02b"
+teal = "#179299"
+sky = "#04a5e5"
+sapphire = "#209fb5"
+blue = "#1e66f5"
+lavender = "#7287fd"
+text = "#4c4f69"
+subtext1 = "#5c5f77"
+subtext0 = "#6c6f85"
+overlay2 = "#7c7f93"
+overlay1 = "#8c8fa1"
+overlay0 = "#9ca0b0"
+surface2 = "#acb0be"
+surface1 = "#bcc0cc"
+surface0 = "#ccd0da"
+base = "#eff1f5"
+mantle = "#e6e9ef"
+crust = "#dce0e8"
+
+[palettes.catppuccin_macchiato]
+rosewater = "#f4dbd6"
+flamingo = "#f0c6c6"
+pink = "#f5bde6"
+mauve = "#c6a0f6"
+red = "#ed8796"
+maroon = "#ee99a0"
+peach = "#f5a97f"
+yellow = "#eed49f"
+green = "#a6da95"
+teal = "#8bd5ca"
+sky = "#91d7e3"
+sapphire = "#7dc4e4"
+blue = "#8aadf4"
+lavender = "#b7bdf8"
+text = "#cad3f5"
+subtext1 = "#b8c0e0"
+subtext0 = "#a5adcb"
+overlay2 = "#939ab7"
+overlay1 = "#8087a2"
+overlay0 = "#6e738d"
+surface2 = "#5b6078"
+surface1 = "#494d64"
+surface0 = "#363a4f"
+base = "#24273a"
+mantle = "#1e2030"
+crust = "#181926"

--- a/starship-themes/dxs-starship.toml
+++ b/starship-themes/dxs-starship.toml
@@ -1,0 +1,1 @@
+../starship.toml

--- a/starship-themes/gruvbox-rainbow.toml
+++ b/starship-themes/gruvbox-rainbow.toml
@@ -1,0 +1,181 @@
+"$schema" = 'https://starship.rs/config-schema.json'
+
+format = """
+[](color_orange)\
+$os\
+$username\
+[](bg:color_yellow fg:color_orange)\
+$directory\
+[](fg:color_yellow bg:color_aqua)\
+$git_branch\
+$git_status\
+[](fg:color_aqua bg:color_blue)\
+$c\
+$cpp\
+$rust\
+$golang\
+$nodejs\
+$php\
+$java\
+$kotlin\
+$haskell\
+$python\
+[](fg:color_blue bg:color_bg3)\
+$docker_context\
+$conda\
+$pixi\
+[](fg:color_bg3 bg:color_bg1)\
+$time\
+[ ](fg:color_bg1)\
+$line_break$character"""
+
+palette = 'gruvbox_dark'
+
+[palettes.gruvbox_dark]
+color_fg0 = '#fbf1c7'
+color_bg1 = '#3c3836'
+color_bg3 = '#665c54'
+color_blue = '#458588'
+color_aqua = '#689d6a'
+color_green = '#98971a'
+color_orange = '#d65d0e'
+color_purple = '#b16286'
+color_red = '#cc241d'
+color_yellow = '#d79921'
+
+[os]
+disabled = false
+style = "bg:color_orange fg:color_fg0"
+
+[os.symbols]
+Windows = "󰍲"
+Ubuntu = "󰕈"
+SUSE = ""
+Raspbian = "󰐿"
+Mint = "󰣭"
+Macos = "󰀵"
+Manjaro = ""
+Linux = "󰌽"
+Gentoo = "󰣨"
+Fedora = "󰣛"
+Alpine = ""
+Amazon = ""
+Android = ""
+AOSC = ""
+Arch = "󰣇"
+Artix = "󰣇"
+EndeavourOS = ""
+CentOS = ""
+Debian = "󰣚"
+Redhat = "󱄛"
+RedHatEnterprise = "󱄛"
+Pop = ""
+
+[username]
+show_always = true
+style_user = "bg:color_orange fg:color_fg0"
+style_root = "bg:color_orange fg:color_fg0"
+format = '[ $user ]($style)'
+
+[directory]
+style = "fg:color_fg0 bg:color_yellow"
+format = "[ $path ]($style)"
+truncation_length = 3
+truncation_symbol = "…/"
+
+[directory.substitutions]
+"Documents" = "󰈙 "
+"Downloads" = " "
+"Music" = "󰝚 "
+"Pictures" = " "
+"Developer" = "󰲋 "
+
+[git_branch]
+symbol = ""
+style = "bg:color_aqua"
+format = '[[ $symbol $branch ](fg:color_fg0 bg:color_aqua)]($style)'
+
+[git_status]
+style = "bg:color_aqua"
+format = '[[($all_status$ahead_behind )](fg:color_fg0 bg:color_aqua)]($style)'
+
+[nodejs]
+symbol = ""
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[c]
+symbol = " "
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[cpp]
+symbol = " "
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[rust]
+symbol = ""
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[golang]
+symbol = ""
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[php]
+symbol = ""
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[java]
+symbol = ""
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[kotlin]
+symbol = ""
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[haskell]
+symbol = ""
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[python]
+symbol = ""
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[docker_context]
+symbol = ""
+style = "bg:color_bg3"
+format = '[[ $symbol( $context) ](fg:#83a598 bg:color_bg3)]($style)'
+
+[conda]
+style = "bg:color_bg3"
+format = '[[ $symbol( $environment) ](fg:#83a598 bg:color_bg3)]($style)'
+
+[pixi]
+style = "bg:color_bg3"
+format = '[[ $symbol( $version)( $environment) ](fg:color_fg0 bg:color_bg3)]($style)'
+
+[time]
+disabled = false
+time_format = "%R"
+style = "bg:color_bg1"
+format = '[[  $time ](fg:color_fg0 bg:color_bg1)]($style)'
+
+[line_break]
+disabled = false
+
+[character]
+disabled = false
+success_symbol = '[](bold fg:color_green)'
+error_symbol = '[](bold fg:color_red)'
+vimcmd_symbol = '[](bold fg:color_green)'
+vimcmd_replace_one_symbol = '[](bold fg:color_purple)'
+vimcmd_replace_symbol = '[](bold fg:color_purple)'
+vimcmd_visual_symbol = '[](bold fg:color_yellow)'

--- a/starship-themes/nerd-font-symbols.toml
+++ b/starship-themes/nerd-font-symbols.toml
@@ -1,0 +1,308 @@
+"$schema" = 'https://starship.rs/config-schema.json'
+
+[aws]
+symbol = " "
+
+[azure]
+symbol = " "
+
+[battery]
+full_symbol = "󰁹 "
+charging_symbol = "󰂄 "
+discharging_symbol = "󰂃 "
+unknown_symbol = "󰂑 "
+empty_symbol = "󰂎 "
+
+[buf]
+symbol = " "
+
+[bun]
+symbol = " "
+
+[c]
+symbol = " "
+
+[cpp]
+symbol = " "
+
+[cmake]
+symbol = " "
+
+[cobol]
+symbol = " "
+
+[conda]
+symbol = " "
+
+[container]
+symbol = " "
+
+[crystal]
+symbol = " "
+
+[dart]
+symbol = " "
+
+[deno]
+symbol = " "
+
+[direnv]
+symbol = " "
+
+[directory]
+read_only = " 󰌾"
+
+[docker_context]
+symbol = " "
+
+[dotnet]
+symbol = " "
+
+[elixir]
+symbol = " "
+
+[elm]
+symbol = " "
+
+[erlang]
+symbol = " "
+
+[fennel]
+symbol = " "
+
+[fortran]
+symbol = " "
+
+[fossil_branch]
+symbol = " "
+
+[gcloud]
+symbol = "󱇶 "
+
+[gleam]
+symbol = " "
+
+[git_branch]
+symbol = " "
+
+[git_commit]
+tag_symbol = '  '
+
+[golang]
+symbol = " "
+
+[gradle]
+symbol = " "
+
+[guix_shell]
+symbol = " "
+
+[haskell]
+symbol = " "
+
+[haxe]
+symbol = " "
+
+[helm]
+symbol = " "
+
+[hg_branch]
+symbol = " "
+
+[hostname]
+ssh_symbol = " "
+
+[java]
+symbol = " "
+
+[julia]
+symbol = " "
+
+[kotlin]
+symbol = " "
+
+[kubernetes]
+symbol = "󱃾 "
+
+[lua]
+symbol = " "
+
+[maven]
+symbol = " "
+
+[memory_usage]
+symbol = "󰍛 "
+
+[meson]
+symbol = "󰔷 "
+
+[mojo]
+symbol = "󰈸 "
+
+[nats]
+symbol = " "
+
+[netns]
+symbol = "󰛳 "
+
+[nim]
+symbol = " "
+
+[nix_shell]
+symbol = " "
+
+[nodejs]
+symbol = " "
+
+[ocaml]
+symbol = " "
+
+[odin]
+symbol = "󰟢 "
+
+[opa]
+symbol = " "
+
+[openstack]
+symbol = " "
+
+[os.symbols]
+AIX = " "
+AlmaLinux = " "
+Alpaquita = " "
+Alpine = " "
+ALTLinux = " "
+Amazon = " "
+Android = " "
+AOSC = " "
+Arch = " "
+Artix = " "
+Bluefin = " "
+CachyOS = " "
+CentOS = " "
+Debian = " "
+DragonFly = " "
+Elementary = " "
+Emscripten = " "
+EndeavourOS = " "
+Fedora = " "
+FreeBSD = " "
+Garuda = " "
+Gentoo = " "
+HardenedBSD = "󰞌 "
+Illumos = " "
+InstantOS = " "
+Ios = "󰀷 "
+Kali = " "
+Linux = " "
+Mabox = " "
+Macos = " "
+Manjaro = " "
+Mariner = " "
+MidnightBSD = " "
+Mint = " "
+NetBSD = " "
+NixOS = " "
+Nobara = " "
+OpenBSD = " "
+OpenCloudOS = " "
+openEuler = " "
+openSUSE = " "
+OracleLinux = "󰺡 "
+PikaOS = " "
+Pop = " "
+Raspbian = " "
+Redhat = "󱄛 "
+RedHatEnterprise = "󱄛 "
+Redox = "󰀘 "
+RockyLinux = " "
+Solus = " "
+SUSE = " "
+Ubuntu = " "
+Ultramarine = " "
+Unknown = " "
+Uos = " "
+Void = " "
+Windows = "󰍲 "
+Zorin = " "
+
+[package]
+symbol = "󰏗 "
+
+[perl]
+symbol = " "
+
+[php]
+symbol = " "
+
+[pijul_channel]
+symbol = " "
+
+[pixi]
+symbol = "󰏗 "
+
+[pulumi]
+symbol = " "
+
+[purescript]
+symbol = " "
+
+[python]
+symbol = " "
+
+[raku]
+symbol = "󱖊 "
+
+[red]
+symbol = "󱍼 "
+
+[rlang]
+symbol = "󰟔 "
+
+[ruby]
+symbol = " "
+
+[rust]
+symbol = "󱘗 "
+
+[scala]
+symbol = " "
+
+[shlvl]
+symbol = "󰹍 "
+
+[singularity]
+symbol = " "
+
+[solidity]
+symbol = " "
+
+[spack]
+symbol = " "
+
+[status]
+symbol = " "
+
+[sudo]
+symbol = " "
+
+[swift]
+symbol = " "
+
+[terraform]
+symbol = " "
+
+[vlang]
+symbol = " "
+
+[typst]
+symbol = " "
+
+[vagrant]
+symbol = " "
+
+[xmake]
+symbol = " "
+
+[zig]
+symbol = " "

--- a/starship-themes/pastel-powerline.toml
+++ b/starship-themes/pastel-powerline.toml
@@ -1,0 +1,156 @@
+"$schema" = 'https://starship.rs/config-schema.json'
+
+format = """
+[](#9A348E)\
+$os\
+$username\
+[](bg:#DA627D fg:#9A348E)\
+$directory\
+[](fg:#DA627D bg:#FCA17D)\
+$git_branch\
+$git_status\
+[](fg:#FCA17D bg:#86BBD8)\
+$c\
+$elixir\
+$elm\
+$golang\
+$gradle\
+$haskell\
+$java\
+$julia\
+$maven\
+$nodejs\
+$nim\
+$rust\
+$scala\
+[](fg:#86BBD8 bg:#06969A)\
+$docker_context\
+[](fg:#06969A bg:#33658A)\
+$time\
+[ ](fg:#33658A)\
+"""
+
+# Disable the blank line at the start of the prompt
+# add_newline = false
+
+# You can also replace your username with a neat symbol like   or disable this
+# and use the os module below
+[username]
+show_always = true
+style_user = "bg:#9A348E"
+style_root = "bg:#9A348E"
+format = '[$user ]($style)'
+disabled = false
+
+# An alternative to the username module which displays a symbol that
+# represents the current operating system
+[os]
+style = "bg:#9A348E"
+disabled = true # Disabled by default
+
+[directory]
+style = "bg:#DA627D"
+format = "[ $path ]($style)"
+truncation_length = 3
+truncation_symbol = "…/"
+
+# Here is how you can shorten some long paths by text replacement
+# similar to mapped_locations in Oh My Posh:
+[directory.substitutions]
+"Documents" = "󰈙 "
+"Downloads" = " "
+"Music" = " "
+"Pictures" = " "
+# Keep in mind that the order matters. For example:
+# "Important Documents" = " 󰈙 "
+# will not be replaced, because "Documents" was already substituted before.
+# So either put "Important Documents" before "Documents" or use the substituted version:
+# "Important 󰈙 " = " 󰈙 "
+
+[c]
+symbol = " "
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[cpp]
+symbol = " "
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[docker_context]
+symbol = " "
+style = "bg:#06969A"
+format = '[ $symbol $context ]($style)'
+
+[elixir]
+symbol = " "
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[elm]
+symbol = " "
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[git_branch]
+symbol = ""
+style = "bg:#FCA17D"
+format = '[ $symbol $branch ]($style)'
+
+[git_status]
+style = "bg:#FCA17D"
+format = '[$all_status$ahead_behind ]($style)'
+
+[golang]
+symbol = " "
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[gradle]
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[haskell]
+symbol = " "
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[java]
+symbol = " "
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[julia]
+symbol = " "
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[maven]
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[nodejs]
+symbol = ""
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[nim]
+symbol = "󰆥 "
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[rust]
+symbol = ""
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[scala]
+symbol = " "
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[time]
+disabled = false
+time_format = "%R" # Hour:Minute Format
+style = "bg:#33658A"
+format = '[ ♥ $time ]($style)'

--- a/starship-themes/tokyo-night.toml
+++ b/starship-themes/tokyo-night.toml
@@ -1,0 +1,66 @@
+"$schema" = 'https://starship.rs/config-schema.json'
+
+format = """
+[░▒▓](#a3aed2)\
+[  ](bg:#a3aed2 fg:#090c0c)\
+[](bg:#769ff0 fg:#a3aed2)\
+$directory\
+[](fg:#769ff0 bg:#394260)\
+$git_branch\
+$git_status\
+[](fg:#394260 bg:#212736)\
+$nodejs\
+$rust\
+$golang\
+$php\
+[](fg:#212736 bg:#1d2230)\
+$time\
+[ ](fg:#1d2230)\
+\n$character"""
+
+[directory]
+style = "fg:#e3e5e5 bg:#769ff0"
+format = "[ $path ]($style)"
+truncation_length = 3
+truncation_symbol = "…/"
+
+[directory.substitutions]
+"Documents" = "󰈙 "
+"Downloads" = " "
+"Music" = " "
+"Pictures" = " "
+
+[git_branch]
+symbol = ""
+style = "bg:#394260"
+format = '[[ $symbol $branch ](fg:#769ff0 bg:#394260)]($style)'
+
+[git_status]
+style = "bg:#394260"
+format = '[[($all_status$ahead_behind )](fg:#769ff0 bg:#394260)]($style)'
+
+[nodejs]
+symbol = ""
+style = "bg:#212736"
+format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+
+[rust]
+symbol = ""
+style = "bg:#212736"
+format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+
+[golang]
+symbol = ""
+style = "bg:#212736"
+format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+
+[php]
+symbol = ""
+style = "bg:#212736"
+format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+
+[time]
+disabled = false
+time_format = "%R" # Hour:Minute Format
+style = "bg:#1d2230"
+format = '[[  $time ](fg:#a0a9cb bg:#1d2230)]($style)'


### PR DESCRIPTION
Adds a catalogue of seven Starship presets (the original DXSBash config, renamed "DXS Starship", plus the six most popular official presets: Nerd Font Symbols, Bracketed Segments, Pastel Powerline, Tokyo Night, Gruvbox Rainbow, Catppuccin Powerline) under starship-themes/, and wires them into dxsbash-config as a new "Starship theme" submenu.

Theme selection re-points ~/.config/starship.toml at the chosen preset file, persists the choice as DXSBASH_STARSHIP_THEME in ~/.dxsbash/user.conf, and auto-switches the prompt style back to "starship" so the theme actually takes effect. load_config also reconciles from the live symlink so the dashboard stays honest when the symlink is changed outside the tool. Reset-to-defaults restores the DXS Starship symlink.

The six official presets are verbatim copies from the Starship docs repository; dxs-starship.toml is a symlink to ../starship.toml so the repo keeps a single source of truth for the DXSBash preset.